### PR TITLE
fix: using local[*] leads to wrong results

### DIFF
--- a/src/main/scala/frl/driesprong/outlierdectection/EvaluateOutlierDetection.scala
+++ b/src/main/scala/frl/driesprong/outlierdectection/EvaluateOutlierDetection.scala
@@ -6,7 +6,7 @@ object EvaluateOutlierDetection {
 
   def main(args: Array[String]) {
     val conf = new SparkConf()
-      .setMaster("local[*]")
+      .setMaster("local")
       .setAppName("Stochastic Outlier Selection")
 
     val sc = new SparkContext(conf)


### PR DESCRIPTION
changing spark master from _local[*]_ to _local_ - parallelism seems to lead to wrong results in outlier probability computation